### PR TITLE
Implement a validating digital input that only returns the real input…

### DIFF
--- a/src/main/java/frc/lib/util/ValidatingDigitalInput.java
+++ b/src/main/java/frc/lib/util/ValidatingDigitalInput.java
@@ -1,0 +1,106 @@
+package frc.lib.util;
+
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import edu.wpi.first.wpilibj.DigitalInput;
+
+/**
+ * A digital input that provides a robustness check, and a default value if the
+ * input is stuck one way or the other. This is useful for inputs that have
+ * failed in one state or the other. The default value will ALWAYS be returned,
+ * if the actual input state never changes. So plan accordingly! A use case is a
+ * limit switch on some mechanism that may stop operating because it is
+ * unplugged or gets stuck as triggered. The default value to return is NOT
+ * necessarily the expected starting value, but instead the value that you wish
+ * to always return when the device no longer operates. Call `rawGet` if you
+ * want the real value.
+ * 
+ * Note: a failure state is defined as the sensor being stuck high or low since
+ * the robot has started (or since being set to invalid). This does not detect
+ * failures such as intermittent high or low values, or values that make no
+ * sense in context (for example a high and low limit switch being triggered at
+ * the same time)
+ */
+public class ValidatingDigitalInput implements Sendable {
+    private enum State {
+        initialize,
+        failedTrue,
+        failedFalse,
+        valid
+    }
+    private State state = State.initialize;
+
+    private boolean defaultValue;
+
+    private DigitalInput realInput;
+
+    public ValidatingDigitalInput(int channel, boolean defaultValue) {
+        realInput = new DigitalInput(channel);
+        this.defaultValue = defaultValue;
+    }
+
+    /**
+     * Get the value of the input, which is the default value if the sensor is not yet marked as valid.
+     * 
+     * @return `defaultValue` if the input has not been validated yet, the real input value otherwise.
+     *         false = 0V, true = 5V.
+     */
+    public boolean get() {
+        var realValue = realInput.get();
+        switch(state) {
+            case initialize:
+                state = realValue ? State.failedTrue : State.failedFalse;
+                break;
+            case failedTrue:
+                if(!realValue)
+                {
+                    state = State.valid;
+                    return realValue;
+                }
+                break;
+            case failedFalse:
+                if(realValue)
+                {
+                    state = State.valid;
+                    return realValue;
+                }
+                break;
+            case valid:
+                return realValue;
+            default:
+                assert false : "Invalid state condition!";
+                break;
+        }
+        return defaultValue;
+    }
+
+    /**
+     * @return true if the state is determined to be valid (the sensor is operational)
+     */
+    public boolean valid() {
+        return state == State.valid;
+    }
+
+    /**
+     * Reset the validation state, the sensor will now return the default value
+     * until it is validated.
+     */
+    public void invalidate() {
+        state = State.initialize;
+    }
+
+    /**
+     * The real input from the dio port.
+     * 
+     * @return The digital input object that is actually reading the io port.
+     */
+    public DigitalInput rawInput() {
+        return realInput;
+    }
+
+    public void initSendable(SendableBuilder builder) {
+        builder.setSmartDashboardType("Validating Digital Input");
+        builder.addBooleanProperty("Value", this::get, null);
+        builder.addBooleanProperty("Valid", this::valid, null);
+    }
+}

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorIONeo.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorIONeo.java
@@ -10,9 +10,10 @@ import com.revrobotics.spark.SparkMax;
 import com.revrobotics.spark.config.ClosedLoopConfig;
 import com.revrobotics.spark.config.ClosedLoopConfig.FeedbackSensor;
 import com.revrobotics.spark.config.SparkMaxConfig;
-import edu.wpi.first.wpilibj.DigitalInput;
 import frc.lib.constants.RobotConstants;
 import frc.lib.util.BasePosition;
+import frc.lib.util.ValidatingDigitalInput;
+
 import org.littletonrobotics.junction.Logger;
 
 public class ElevatorIONeo implements ElevatorIO {
@@ -26,8 +27,8 @@ public class ElevatorIONeo implements ElevatorIO {
   private final SparkMaxConfig leadConfig;
   private final SparkMaxConfig followConfig;
 
-  private final DigitalInput bottomLimitSwitch;
-  private final DigitalInput topLimitSwitch;
+  private final ValidatingDigitalInput bottomLimitSwitch;
+  private final ValidatingDigitalInput topLimitSwitch;
 
   private final double encoderLowerLimit = 0.0;
   private final double encoderUpperLimit = 280.0;
@@ -35,8 +36,8 @@ public class ElevatorIONeo implements ElevatorIO {
 
   public ElevatorIONeo() {
 
-    bottomLimitSwitch = new DigitalInput(RobotConstants.ElevatorConstants.bottomlimitswitchID);
-    topLimitSwitch = new DigitalInput(RobotConstants.ElevatorConstants.toplimitswitchID);
+    bottomLimitSwitch = new ValidatingDigitalInput(RobotConstants.ElevatorConstants.bottomlimitswitchID, false);
+    topLimitSwitch = new ValidatingDigitalInput(RobotConstants.ElevatorConstants.toplimitswitchID, false);
 
     leadMotor = new SparkMax(RobotConstants.ElevatorConstants.leadMotorID, MotorType.kBrushless);
     followMotor =


### PR DESCRIPTION
… state if it has seen things move once. Switch elevator limit switches to these inputs, so they will not be subject to broken sensors causing the robot to try and go beyond the elevator limits.

The current sensor setup is bad -- if the upper limit sensor wire is broken, the code will think the elevator is *always* at the highest point, or if it is at the lower level, it will always think the elevator is at the lowest point, meaning any elevator moves will be always up or always down!

This will validate that the sensor is at least valid when first used. The default value of `false` means it will not trigger any limits that set the elevator encoder positions.

This will *not* protect against a sensor failing mid-match. We should have a manual mechanism to disable the limit switches, and somehow manually recalibrate the encoder. We can talk about this later.